### PR TITLE
Feature/20 migration prefectures

### DIFF
--- a/database/migrations/2023_10_29_114642_create_prefectures_table.php
+++ b/database/migrations/2023_10_29_114642_create_prefectures_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('prefectures', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('prefectures');
+    }
+};

--- a/database/migrations/2023_10_29_114642_create_prefectures_table.php
+++ b/database/migrations/2023_10_29_114642_create_prefectures_table.php
@@ -13,6 +13,9 @@ return new class extends Migration
     {
         Schema::create('prefectures', function (Blueprint $table) {
             $table->id();
+            $table->string('name', 10)->comment('都道府県名');
+            $table->string('en_name', 20)->comment('都道府県名の英語表記');
+            $table->string('code', 10)->comment('都道府県コード');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_10_29_115711_create_cities_table.php
+++ b/database/migrations/2023_10_29_115711_create_cities_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cities');
+    }
+};

--- a/database/migrations/2023_10_29_115711_create_cities_table.php
+++ b/database/migrations/2023_10_29_115711_create_cities_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
     {
         Schema::create('cities', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('prefecture_id')->constrained();
+            $table->string('name', 10)->comment('市区町村名');
+            $table->string('en_name', 40)->comment('市区町村名の英語表記');
+            $table->string('code', 20)->comment('市区町村コード');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_10_29_115711_create_cities_table.php
+++ b/database/migrations/2023_10_29_115711_create_cities_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('cities', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('prefecture_id')->constrained();
+            $table->foreignId('prefecture_id')->constrained('prefectures');
             $table->string('name', 10)->comment('市区町村名');
             $table->string('en_name', 40)->comment('市区町村名の英語表記');
             $table->string('code', 20)->comment('市区町村コード');

--- a/database/migrations/2023_10_29_121729_create_city_islands_table.php
+++ b/database/migrations/2023_10_29_121729_create_city_islands_table.php
@@ -13,6 +13,8 @@ return new class extends Migration
     {
         Schema::create('city_islands', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('city_id')->constrained();
+            $table->foreignId('island_id')->constrained();
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_10_29_121729_create_city_islands_table.php
+++ b/database/migrations/2023_10_29_121729_create_city_islands_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('city_islands', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('city_islands');
+    }
+};

--- a/database/migrations/2023_10_29_121729_create_city_islands_table.php
+++ b/database/migrations/2023_10_29_121729_create_city_islands_table.php
@@ -13,9 +13,10 @@ return new class extends Migration
     {
         Schema::create('city_islands', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('city_id')->constrained();
-            $table->foreignId('island_id')->constrained();
-            $table->timestamps();
+            $table->foreignId('city_id')->constrained('cities');
+            $table->foreignId('island_id')->constrained('islands');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
         });
     }
 

--- a/tests/Unit/CitiesTableTest.php
+++ b/tests/Unit/CitiesTableTest.php
@@ -15,14 +15,14 @@ class CitiesTableTest extends TestCase
      */
     public function test_exists_cities_table(): void
     {
-        /**
-         * テーブルが存在するか
-         */
         $this->assertTrue(Schema::hasTable('cities'));
+    }
 
-        /**
-         * 必要なカラムが存在するか
-         */
+    /**
+    * 必要なカラムが存在するか
+    */
+    public function test_has_columns(): void
+    {
         $this->assertTrue(Schema::hasColumns('cities', [
             'id',
             'prefecture_id',
@@ -32,10 +32,13 @@ class CitiesTableTest extends TestCase
             'created_at',
             'updated_at',
         ]));
+    }
 
-        /**
-         * prefecture_idはprefecturesテーブルのidを参照しているか
-         */
+    /**
+    * prefecture_idはprefecturesテーブルのidを参照しているか
+    */
+    public function test_prefecture_id_foreign(): void
+    {
         $this->assertTrue(Schema::enableForeignKeyConstraints('prefecture_id'));
     }
 }

--- a/tests/Unit/CitiesTableTest.php
+++ b/tests/Unit/CitiesTableTest.php
@@ -19,5 +19,23 @@ class CitiesTableTest extends TestCase
          * テーブルが存在するか
          */
         $this->assertTrue(Schema::hasTable('cities'));
+
+        /**
+         * 必要なカラムが存在するか
+         */
+        $this->assertTrue(Schema::hasColumns('cities', [
+            'id',
+            'prefecture_id',
+            'name',
+            'en_name',
+            'code',
+            'created_at',
+            'updated_at',
+        ]));
+
+        /**
+         * prefecture_idはprefecturesテーブルのidを参照しているか
+         */
+        $this->assertTrue(Schema::enableForeignKeyConstraints('prefecture_id'));
     }
 }

--- a/tests/Unit/CitiesTableTest.php
+++ b/tests/Unit/CitiesTableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class CitiesTableTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * citiesテーブルが存在するかどうか
+     */
+    public function test_exists_cities_table(): void
+    {
+        /**
+         * テーブルが存在するか
+         */
+        $this->assertTrue(Schema::hasTable('cities'));
+    }
+}

--- a/tests/Unit/CitiesTableTest.php
+++ b/tests/Unit/CitiesTableTest.php
@@ -19,9 +19,9 @@ class CitiesTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するか
+    * 必要なカラムが存在するかどうか
     */
-    public function test_has_columns(): void
+    public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('cities', [
             'id',

--- a/tests/Unit/CityIslandsTableTest.php
+++ b/tests/Unit/CityIslandsTableTest.php
@@ -19,5 +19,16 @@ class CityIslandsTableTest extends TestCase
          * テーブルが存在するか
          */
         $this->assertTrue(Schema::hasTable('city_islands'));
+
+        /**
+         * 必要なカラムが存在するか
+         */
+        $this->assertTrue(Schema::hasColumns('city_islands', [
+            'id',
+            'city_id',
+            'island_id',
+            'created_at',
+            'updated_at',
+        ]));
     }
 }

--- a/tests/Unit/CityIslandsTableTest.php
+++ b/tests/Unit/CityIslandsTableTest.php
@@ -19,9 +19,9 @@ class CityIslandsTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するか
+    * 必要なカラムが存在するかどうか
     */
-    public function test_has_columns(): void
+    public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('city_islands', [
             'id',
@@ -30,5 +30,21 @@ class CityIslandsTableTest extends TestCase
             'created_at',
             'updated_at',
         ]));
+    }
+
+    /**
+    * city_idはcitiesテーブルのidを参照しているか
+    */
+    public function test_city_id_foreign(): void
+    {
+        $this->assertTrue(Schema::enableForeignKeyConstraints('city_id'));
+    }
+
+    /**
+    * island_idはislandsテーブルのidを参照しているか
+    */
+    public function test_island_id_foreign(): void
+    {
+        $this->assertTrue(Schema::enableForeignKeyConstraints('island_id'));
     }
 }

--- a/tests/Unit/CityIslandsTableTest.php
+++ b/tests/Unit/CityIslandsTableTest.php
@@ -15,14 +15,14 @@ class CityIslandsTableTest extends TestCase
      */
     public function test_exists_city_islands_table(): void
     {
-        /**
-         * テーブルが存在するか
-         */
         $this->assertTrue(Schema::hasTable('city_islands'));
+    }
 
-        /**
-         * 必要なカラムが存在するか
-         */
+    /**
+    * 必要なカラムが存在するか
+    */
+    public function test_has_columns(): void
+    {
         $this->assertTrue(Schema::hasColumns('city_islands', [
             'id',
             'city_id',

--- a/tests/Unit/CityIslandsTableTest.php
+++ b/tests/Unit/CityIslandsTableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class CityIslandsTableTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * city_islandsテーブルが存在するかどうか
+     */
+    public function test_exists_city_islands_table(): void
+    {
+        /**
+         * テーブルが存在するか
+         */
+        $this->assertTrue(Schema::hasTable('city_islands'));
+    }
+}

--- a/tests/Unit/IslandsTableTest.php
+++ b/tests/Unit/IslandsTableTest.php
@@ -19,9 +19,9 @@ class IslandsTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するか
+    * 必要なカラムが存在するかどうか
     */
-    public function test_has_columns(): void
+    public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('islands', [
             'id',

--- a/tests/Unit/IslandsTableTest.php
+++ b/tests/Unit/IslandsTableTest.php
@@ -15,14 +15,14 @@ class IslandsTableTest extends TestCase
      */
     public function test_islands_table_exists(): void
     {
-        /**
-         * テーブルが存在するか
-         */
         $this->assertTrue(Schema::hasTable('islands'));
+    }
 
-        /**
-         * 必要なカラムが存在するか
-         */
+    /**
+    * 必要なカラムが存在するか
+    */
+    public function test_has_columns(): void
+    {
         $this->assertTrue(Schema::hasColumns('islands', [
             'id',
             'firestore_id',

--- a/tests/Unit/PrefecturesTableTest.php
+++ b/tests/Unit/PrefecturesTableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class PrefecturesTableTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * prefecturesテーブルが存在するかどうか
+     */
+    public function test_exists_prefectures_table(): void
+    {
+        /**
+         * テーブルが存在するか
+         */
+        $this->assertTrue(Schema::hasTable('prefectures'));
+    }
+}

--- a/tests/Unit/PrefecturesTableTest.php
+++ b/tests/Unit/PrefecturesTableTest.php
@@ -19,5 +19,17 @@ class PrefecturesTableTest extends TestCase
          * テーブルが存在するか
          */
         $this->assertTrue(Schema::hasTable('prefectures'));
+
+        /**
+         * 必要なカラムが存在するか
+         */
+        $this->assertTrue(Schema::hasColumns('prefectures', [
+            'id',
+            'name',
+            'en_name',
+            'code',
+            'created_at',
+            'updated_at',
+        ]));
     }
 }

--- a/tests/Unit/PrefecturesTableTest.php
+++ b/tests/Unit/PrefecturesTableTest.php
@@ -15,14 +15,14 @@ class PrefecturesTableTest extends TestCase
      */
     public function test_exists_prefectures_table(): void
     {
-        /**
-         * テーブルが存在するか
-         */
         $this->assertTrue(Schema::hasTable('prefectures'));
+    }
 
-        /**
-         * 必要なカラムが存在するか
-         */
+    /**
+    * 必要なカラムが存在するか
+    */
+    public function test_has_columns(): void
+    {
         $this->assertTrue(Schema::hasColumns('prefectures', [
             'id',
             'name',

--- a/tests/Unit/PrefecturesTableTest.php
+++ b/tests/Unit/PrefecturesTableTest.php
@@ -19,9 +19,9 @@ class PrefecturesTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するか
+    * 必要なカラムが存在するかどうか
     */
-    public function test_has_columns(): void
+    public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('prefectures', [
             'id',


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `create_prefectures_table.php`, `create_cities_table.php`, `create_city_islands_table.php`の3つのマイグレーションファイルが追加されました。これらのファイルは、都道府県テーブル、市区町村テーブル、および市区町村と島の関連を管理するためのテーブルを作成します。
- Test: `PrefecturesTableTest.php`, `CitiesTableTest.php`, `CityIslandsTableTest.php`, `IslandsTableTest.php`の4つのテストクラスが追加されました。これらのテストは、各テーブルの存在と必要なカラムの有無を確認します。

以上の変更により、データベースの構造が拡張され、都道府県、市区町村、島の情報を効果的に管理できるようになります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->