### PR TITLE
#24 IslandControllerの追加

### DIFF
--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class IslandController extends Controller
+{
+    public function index()
+    {
+        return view('island.index');
+    }
+}

--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -27,6 +27,10 @@ class IslandController extends Controller
     public function show(int $id): \Illuminate\View\View
     {
         $island = Island::find($id);
-        return view('island.show', compact('island'));
+        if ($island !== null) {
+            return view('island.show', compact('island'));
+        } else {
+            abort(404);
+        }
     }
 }

--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -17,4 +17,16 @@ class IslandController extends Controller
         $islands = Island::getAll();
         return view('island.index', compact('islands'));
     }
+
+    /**
+     * 島の詳細画面を表示する
+     * @param int $id
+     *
+     * @return \Illuminate\View\View
+     */
+    public function show(int $id): \Illuminate\View\View
+    {
+        $island = Island::find($id);
+        return view('island.show', compact('island'));
+    }
 }

--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -3,11 +3,18 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Island;
 
 class IslandController extends Controller
 {
-    public function index()
+    /**
+     * 島の一覧画面を表示する
+     *
+     * @return \Illuminate\View\View
+     */
+    public function index(): \Illuminate\View\View
     {
-        return view('island.index');
+        $islands = Island::getAll();
+        return view('island.index', compact('islands'));
     }
 }

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -7,7 +7,7 @@
 @stop
 
 @section('content')
-    <p>トップ</p>
+    <?= var_dump($islands) ?>
 @stop
 
 @section('css')

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -1,0 +1,23 @@
+@extends('adminlte::page')
+
+@section('title', 'Dashboard')
+
+@section('content_header')
+    <h1>ダッシュボード</h1>
+@stop
+
+@section('content')
+    <p>トップ</p>
+@stop
+
+@section('css')
+    {{-- ページごとCSSの指定
+    <link rel="stylesheet" href="/css/xxx.css">
+    --}}
+@stop
+
+@section('js')
+    <script>
+        console.log('ページごとJSの記述');
+    </script>
+@stop

--- a/resources/views/island/show.blade.php
+++ b/resources/views/island/show.blade.php
@@ -1,0 +1,23 @@
+@extends('adminlte::page')
+
+@section('title', 'Dashboard')
+
+@section('content_header')
+    <h1>ダッシュボード</h1>
+@stop
+
+@section('content')
+    <?= var_dump($island) ?>
+@stop
+
+@section('css')
+    {{-- ページごとCSSの指定
+    <link rel="stylesheet" href="/css/xxx.css">
+    --}}
+@stop
+
+@section('js')
+    <script>
+        console.log('ページごとJSの記述');
+    </script>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::get('/dashboard', function () {
 
 Route::middleware('auth')->group(function () {
     Route::get('/', [IslandController::class, 'index'])->name('islands.index');
+    Route::get('/island/{id}', [IslandController::class, 'show'])->name('islands.show');
     // Breezeで自動作成されたルート
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Http\Controllers\IslandController;
 use App\Http\Controllers\ProfileController;
+
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -19,9 +21,7 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
-    Route::get('/', function () {
-    return view('welcome');
-});
+    Route::get('/', [IslandController::class, 'index'])->name('islands.index');
     // Breezeで自動作成されたルート
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -64,6 +64,15 @@ class IslandControllerTest extends TestCase
         $response->assertViewHas('island');
     }
 
-    // TODO: 島のデータが存在しない場合は、404エラーが返ってくるかテスト
+    /**
+     * 詳細ページで島のデータが存在しない場合は、404ページを表示するテスト
+     * @return void
+     */
+    public function test_show_404_when_island_not_found(): void
+    {
+        $response = $this->actingAs($this->user)->get("/island/101");
+
+        $response->assertStatus(404);
+    }
     // TODO: 詳細ページでログインしていない場合は、ログイン画面にリダイレクトされるかテスト
 }

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -22,6 +22,7 @@ class IslandControllerTest extends TestCase
         $response = $this->actingAs($user)->get('/');
 
         $response->assertStatus(200);
+        $response->assertViewIs('island.index');
     }
 
     /**

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -23,6 +23,7 @@ class IslandControllerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertViewIs('island.index');
+        $response->assertViewHas('islands');
     }
 
     /**

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -11,6 +11,16 @@ class IslandControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected $user;
+    protected $islands;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->islands = Island::factory(100)->create();
+    }
+
     /**
      * ログインしている場合は、島の一覧画面が表示されるかテスト
      *
@@ -18,9 +28,7 @@ class IslandControllerTest extends TestCase
      */
     public function test_index_page(): void
     {
-        $user = User::factory()->create();
-
-        $response = $this->actingAs($user)->get('/');
+        $response = $this->actingAs($this->user)->get('/');
 
         $response->assertStatus(200);
         $response->assertViewIs('island.index');
@@ -47,10 +55,9 @@ class IslandControllerTest extends TestCase
      */
     public function test_show_page(): void
     {
-        $user = User::factory()->create();
-        $island = Island::factory()->create();
+        $island = $this->islands->first();
 
-        $response = $this->actingAs($user)->get("/island/{$island->id}");
+        $response = $this->actingAs($this->user)->get("/island/{$island->id}");
 
         $response->assertStatus(200);
         $response->assertViewIs('island.show');

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -35,7 +35,7 @@ class IslandControllerTest extends TestCase
     }
 
     /**
-     * ログインしていない場合は、ログイン画面にリダイレクトされるかテスト
+     * ログインしていない状態で一覧画面にアクセスした場合は、ログイン画面にリダイレクトされるかテスト
      * @return void
      */
     public function test_index_page_when_not_login(): void
@@ -47,7 +47,7 @@ class IslandControllerTest extends TestCase
     }
 
     /**
-     * ログインしている場合は、島の詳細画面が表示されるかテスト
+     * ログインしている状態でisland/{$id}にアクセスした場合は、島の詳細画面が表示されるかテスト
      * @return void
      */
     public function test_show_page(): void

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Tests\TestCase;
+
+class IslandControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * ログインしている場合は、島の一覧画面が表示されるかテスト
+     *
+     * @return void
+     */
+    public function test_index_page(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/');
+
+        $response->assertStatus(200);
+    }
+
+    /**
+     * ログインしていない場合は、ログイン画面にリダイレクトされるかテスト
+     *
+     * @return void
+     */
+    public function test_index_page_when_not_login(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
+    }
+}

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
+use App\Models\Island;
 use Tests\TestCase;
 
 class IslandControllerTest extends TestCase
@@ -38,4 +39,24 @@ class IslandControllerTest extends TestCase
         $response->assertStatus(302);
         $response->assertRedirect('/login');
     }
+
+    /**
+     * ログインしている場合は、島の詳細画面が表示されるかテスト
+     *
+     * @return void
+     */
+    public function test_show_page(): void
+    {
+        $user = User::factory()->create();
+        $island = Island::factory()->create();
+
+        $response = $this->actingAs($user)->get("/island/{$island->id}");
+
+        $response->assertStatus(200);
+        $response->assertViewIs('island.show');
+        $response->assertViewHas('island');
+    }
+
+    // TODO: 島のデータが存在しない場合は、404エラーが返ってくるかテスト
+    // TODO: 詳細ページでログインしていない場合は、ログイン画面にリダイレクトされるかテスト
 }

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -23,7 +23,6 @@ class IslandControllerTest extends TestCase
 
     /**
      * ログインしている場合は、島の一覧画面が表示されるかテスト
-     *
      * @return void
      */
     public function test_index_page(): void
@@ -37,7 +36,6 @@ class IslandControllerTest extends TestCase
 
     /**
      * ログインしていない場合は、ログイン画面にリダイレクトされるかテスト
-     *
      * @return void
      */
     public function test_index_page_when_not_login(): void
@@ -50,7 +48,6 @@ class IslandControllerTest extends TestCase
 
     /**
      * ログインしている場合は、島の詳細画面が表示されるかテスト
-     *
      * @return void
      */
     public function test_show_page(): void
@@ -74,5 +71,18 @@ class IslandControllerTest extends TestCase
 
         $response->assertStatus(404);
     }
-    // TODO: 詳細ページでログインしていない場合は、ログイン画面にリダイレクトされるかテスト
+
+    /**
+     * 詳細ページでログインしていない場合は、ログイン画面にリダイレクトされるかテスト
+     * @return void
+     */
+    public function test_show_page_when_not_login(): void
+    {
+        $island = $this->islands->first();
+
+        $response = $this->get("/island/{$island->id}");
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/login');
+    }
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `IslandController`クラスに`index()`メソッドと`show()`メソッドが追加されました。`index()`メソッドは島の一覧画面を表示し、`show()`メソッドは指定されたIDの島の詳細画面を表示します。
- New Feature: `resources/views/island/index.blade.php`と`resources/views/island/show.blade.php`が追加されました。これらのビューファイルは`IslandController`に関連し、`adminlte::page`を拡張してダッシュボードのタイトルとコンテンツを表示します。また、ページごとのCSSとJavaScriptも指定されています。
- Refactor: `routes/web.php`が更新され、新しい`IslandController`に関連付けられた`islands.index`と`islands.show`のルートが追加されました。
- Test: `tests/Feature/IslandControllerTest.php`にいくつかのテストメソッドが追加されました。これらのテストはログイン状態や島の一覧・詳細画面の表示、存在しない島の処理などをテストしています。

以上の変更が含まれており、これらの変更は`IslandController`とそれに関連するファイルに影響を与えます。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->