### PR TITLE
#26 indexメソッド用のビュー・モデルの追加

### DIFF
--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -13,7 +13,7 @@ class IslandController extends Controller
      */
     public function index(): \Illuminate\View\View
     {
-        $islands = Island::getAllForIndex();
+        $islands = Island::getAllForIndex()->paginate(30);
         return view('island.index', compact('islands'));
     }
 

--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Island;
 
 class IslandController extends Controller
@@ -14,7 +13,7 @@ class IslandController extends Controller
      */
     public function index(): \Illuminate\View\View
     {
-        $islands = Island::getAll();
+        $islands = Island::getAllForIndex();
         return view('island.index', compact('islands'));
     }
 

--- a/app/Http/Controllers/IslandController.php
+++ b/app/Http/Controllers/IslandController.php
@@ -13,7 +13,9 @@ class IslandController extends Controller
      */
     public function index(): \Illuminate\View\View
     {
-        $islands = Island::getAllForIndex()->paginate(30);
+        $ITEMS_PER_PAGE = 30;
+        $islands = Island::getAllForIndex()->paginate($ITEMS_PER_PAGE);
+
         return view('island.index', compact('islands'));
     }
 
@@ -26,6 +28,7 @@ class IslandController extends Controller
     public function show(int $id): \Illuminate\View\View
     {
         $island = Island::find($id);
+
         if ($island !== null) {
             return view('island.show', compact('island'));
         } else {

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class City extends Model
+{
+    use HasFactory;
+}
+

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -8,5 +8,14 @@ use Illuminate\Database\Eloquent\Model;
 class City extends Model
 {
     use HasFactory;
+    //TODO: モデルの単体テストを書く
+
+    /**
+     * 市区町村が属する都道府県を取得
+     */
+    public function prefecture()
+    {
+        return $this->belongsTo(Prefecture::class);
+    }
 }
 

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class City extends Model
 {
     use HasFactory;
-    //TODO: モデルの単体テストを書く
 
     /**
      * 市区町村が属する都道府県を取得

--- a/app/Models/CityIsland.php
+++ b/app/Models/CityIsland.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CityIsland extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Island.php
+++ b/app/Models/Island.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class Island extends Model
 {
@@ -21,13 +22,21 @@ class Island extends Model
     }
 
     /**
-     * 全件取得する
+     * Indexページ用のデータを全件取得する
      *
-     * @return \Illuminate\Database\Eloquent\Collection<Island>
+     * @return array
      */
-    public static function getAll()
+    public static function getAllForIndex()
     {
-        return self::all();
+        //TODO: これをクエリビルダで書き直す
+        $islands = DB::select("
+            select distinct on (islands.id) islands.id, islands.name, prefectures.name as prefecture_name, cities.name as city_name from islands
+            join city_islands on islands.id = city_islands.island_id
+            join cities on city_islands.city_id = cities.id
+            join prefectures on cities.prefecture_id = prefectures.id
+            order by islands.id");
+
+        return $islands;
     }
 
     /**

--- a/app/Models/Island.php
+++ b/app/Models/Island.php
@@ -29,4 +29,12 @@ class Island extends Model
     {
         return self::all();
     }
+
+    /**
+     * CityIslandを通して、市区町村名を取得する
+     */
+    public function cities()
+    {
+        return $this->belongsToMany(City::class, 'city_islands');
+    }
 }

--- a/app/Models/Island.php
+++ b/app/Models/Island.php
@@ -24,7 +24,7 @@ class Island extends Model
     /**
      * Indexページ用のデータを全件取得する
      *
-     * @return array
+     * @return \Illuminate\Database\Query\Builder
      */
     public static function getAllForIndex()
     {
@@ -34,8 +34,7 @@ class Island extends Model
             ->join('city_islands', 'islands.id', '=', 'city_islands.island_id')
             ->join('cities', 'city_islands.city_id', '=', 'cities.id')
             ->join('prefectures', 'cities.prefecture_id', '=', 'prefectures.id')
-            ->orderBy('islands.id')
-            ->get();
+            ->orderBy('islands.id');
 
         return $islands;
     }

--- a/app/Models/Island.php
+++ b/app/Models/Island.php
@@ -28,13 +28,14 @@ class Island extends Model
      */
     public static function getAllForIndex()
     {
-        //TODO: これをクエリビルダで書き直す
-        $islands = DB::select("
-            select distinct on (islands.id) islands.id, islands.name, prefectures.name as prefecture_name, cities.name as city_name from islands
-            join city_islands on islands.id = city_islands.island_id
-            join cities on city_islands.city_id = cities.id
-            join prefectures on cities.prefecture_id = prefectures.id
-            order by islands.id");
+        $islands = DB::table('islands')
+            ->select('islands.id', 'islands.name', 'prefectures.name as prefecture_name', 'cities.name as city_name')
+            ->distinct('islands.id')
+            ->join('city_islands', 'islands.id', '=', 'city_islands.island_id')
+            ->join('cities', 'city_islands.city_id', '=', 'cities.id')
+            ->join('prefectures', 'cities.prefecture_id', '=', 'prefectures.id')
+            ->orderBy('islands.id')
+            ->get();
 
         return $islands;
     }

--- a/app/Models/Prefecture.php
+++ b/app/Models/Prefecture.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Prefecture extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Prefecture.php
+++ b/app/Models/Prefecture.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class Prefecture extends Model
 {
     use HasFactory;
+    //TODO: モデルの単体テストを書く
+
+    /**
+     * この都道府県に属する市区町村を取得
+     */
+    public function cities()
+    {
+        return $this->hasMany(City::class);
+    }
 }

--- a/app/Models/Prefecture.php
+++ b/app/Models/Prefecture.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class Prefecture extends Model
 {
     use HasFactory;
-    //TODO: モデルの単体テストを書く
 
     /**
      * この都道府県に属する市区町村を取得

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Routing\UrlGenerator;
-
+use Illuminate\Pagination\Paginator;
 class AppServiceProvider extends ServiceProvider
 {
     /**
@@ -23,5 +23,7 @@ class AppServiceProvider extends ServiceProvider
         if (env('APP_ENV') == 'production') {
             $url->forceScheme('https');
         }
+
+        Paginator::useBootstrap();
     }
 }

--- a/database/factories/CityFactory.php
+++ b/database/factories/CityFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\City>
+ * CityFactory
  */
 class CityFactory extends Factory
 {
@@ -16,11 +16,14 @@ class CityFactory extends Factory
      */
     public function definition(): array
     {
+        $cityName = $this->faker->city;
         return [
-            'name' => $this->faker->city,
-            'en_name' => $this->faker->city,
-            'code' => $this->faker->city,
-            'prefecture_id' => $this->faker->numberBetween(1, 47),
+            'name' => $cityName,
+            'en_name' => $cityName,
+            'code' => strtoupper(substr($cityName, 0, 3)),
+            'prefecture_id' => function () {
+                return \App\Models\Prefecture::factory()->create()->id;
+            },
         ];
     }
 }

--- a/database/factories/CityFactory.php
+++ b/database/factories/CityFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\City>
+ */
+class CityFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->city,
+            'en_name' => $this->faker->city,
+            'code' => $this->faker->city,
+            'prefecture_id' => $this->faker->numberBetween(1, 47),
+        ];
+    }
+}

--- a/database/factories/PrefectureFactory.php
+++ b/database/factories/PrefectureFactory.php
@@ -5,7 +5,7 @@ namespace Database\Factories;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Prefecture>
+ * PrefectureFactory
  */
 class PrefectureFactory extends Factory
 {

--- a/database/factories/PrefectureFactory.php
+++ b/database/factories/PrefectureFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Prefecture>
+ */
+class PrefectureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->prefecture,
+            'en_name' => $this->faker->prefecture,
+            'code' => $this->faker->prefecture,
+        ];
+    }
+}

--- a/resources/views/components/islands-table.blade.php
+++ b/resources/views/components/islands-table.blade.php
@@ -1,0 +1,41 @@
+@props(['islands'])
+
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">
+                    <div class="input-group input-group-sm" style="width: 150px;">
+                        <input type="text" name="table_search" class="form-control" placeholder="Search">
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-default">
+                                <i class="fas fa-search"></i>
+                            </button>
+                        </div>
+                    </div>
+                </h3>
+            </div>
+            <div class="card-body table-responsive p-0">
+                <table class="table table-hover text-nowrap">
+                    <thead>
+                        <tr>
+                            <th>島名</th>
+                            <th>都道府県名</th>
+                            <th>市区町村名</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($islands as $island): ?>
+                        <tr>
+                            <td><a href="{{ route('islands.show', ['id' => $island->id]) }}">{{ $island->name }}</a>
+                            </td>
+                            <td>{{ $island->prefecture_name }}</td>
+                            <td>{{ $island->city_name }}</td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -39,7 +39,9 @@
                                 <td><a href="{{ route('islands.show', ['id' => $island->id]) }}">{{ $island->name }}</a>
                                 </td>
                                 <td>John Doe</td>
-                                <td>11-7-2014</td>
+                                <?php //TODO: getAllを書き換えるまでの仮置き
+                                ?>
+                                <td>{{ $island->cities->first()->name }}</td>
                             </tr>
                             <?php endforeach; ?>
                         </tbody>

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -38,10 +38,8 @@
                             <tr>
                                 <td><a href="{{ route('islands.show', ['id' => $island->id]) }}">{{ $island->name }}</a>
                                 </td>
-                                <td>John Doe</td>
-                                <?php //TODO: getAllを書き換えるまでの仮置き
-                                ?>
-                                <td>{{ $island->cities->first()->name }}</td>
+                                <td>{{ $island->prefecture_name }}</td>
+                                <td>{{ $island->city_name }}</td>
                             </tr>
                             <?php endforeach; ?>
                         </tbody>

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -7,6 +7,8 @@
 @stop
 
 @section('content')
+    <?php //TODO: 丸ごとコンポーネントに切り出す
+    ?>
     <div class="row">
         <div class="col-12">
             <div class="card">
@@ -34,7 +36,8 @@
                         <tbody>
                             <?php foreach ($islands as $island): ?>
                             <tr>
-                                <td><?= $island->name ?></td>
+                                <td><a href="{{ route('islands.show', ['id' => $island->id]) }}">{{ $island->name }}</a>
+                                </td>
                                 <td>John Doe</td>
                                 <td>11-7-2014</td>
                             </tr>
@@ -45,16 +48,4 @@
             </div>
         </div>
     </div>
-@stop
-
-@section('css')
-    {{-- ページごとCSSの指定
-    <link rel="stylesheet" href="/css/xxx.css">
-    --}}
-@stop
-
-@section('js')
-    <script>
-        console.log('ページごとJSの記述');
-    </script>
 @stop

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -48,4 +48,10 @@
             </div>
         </div>
     </div>
+
+    @if ($islands->hasPages())
+        <div class="card-footer clearfix">
+            {{ $islands->links() }}
+        </div>
+    @endif
 @stop

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -7,7 +7,44 @@
 @stop
 
 @section('content')
-    <?= var_dump($islands) ?>
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">
+                        <div class="input-group input-group-sm" style="width: 150px;">
+                            <input type="text" name="table_search" class="form-control" placeholder="Search">
+                            <div class="input-group-append">
+                                <button type="submit" class="btn btn-default">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </div>
+                        </div>
+                    </h3>
+                </div>
+                <div class="card-body table-responsive p-0">
+                    <table class="table table-hover text-nowrap">
+                        <thead>
+                            <tr>
+                                <th>島名</th>
+                                <th>都道府県名</th>
+                                <th>市区町村名</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($islands as $island): ?>
+                            <tr>
+                                <td><?= $island->name ?></td>
+                                <td>John Doe</td>
+                                <td>11-7-2014</td>
+                            </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
 @stop
 
 @section('css')

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Dashboard')
 
 @section('content_header')
-    <h1>ダッシュボード</h1>
+    <h1>島一覧</h1>
 @stop
 
 @section('content')

--- a/resources/views/island/index.blade.php
+++ b/resources/views/island/index.blade.php
@@ -7,47 +7,7 @@
 @stop
 
 @section('content')
-    <?php //TODO: 丸ごとコンポーネントに切り出す
-    ?>
-    <div class="row">
-        <div class="col-12">
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title">
-                        <div class="input-group input-group-sm" style="width: 150px;">
-                            <input type="text" name="table_search" class="form-control" placeholder="Search">
-                            <div class="input-group-append">
-                                <button type="submit" class="btn btn-default">
-                                    <i class="fas fa-search"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </h3>
-                </div>
-                <div class="card-body table-responsive p-0">
-                    <table class="table table-hover text-nowrap">
-                        <thead>
-                            <tr>
-                                <th>島名</th>
-                                <th>都道府県名</th>
-                                <th>市区町村名</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <?php foreach ($islands as $island): ?>
-                            <tr>
-                                <td><a href="{{ route('islands.show', ['id' => $island->id]) }}">{{ $island->name }}</a>
-                                </td>
-                                <td>{{ $island->prefecture_name }}</td>
-                                <td>{{ $island->city_name }}</td>
-                            </tr>
-                            <?php endforeach; ?>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
+    <x-islands-table :islands="$islands" />
 
     @if ($islands->hasPages())
         <div class="card-footer clearfix">

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -2,23 +2,37 @@
 
 namespace Tests\Feature;
 
+use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
 use App\Models\Island;
-use Tests\TestCase;
+use App\Models\Prefecture;
+use App\Models\City;
+use Illuminate\Support\Facades\DB;
 
 class IslandControllerTest extends TestCase
 {
     use RefreshDatabase;
 
     protected $user;
+    protected $prefecture;
+    protected $city;
     protected $islands;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->user = User::factory()->create();
+        $this->prefecture = Prefecture::factory()->create();
+        $this->city = City::factory()->for($this->prefecture)->create();
         $this->islands = Island::factory(100)->create();
+
+        foreach ($this->islands as $island) {
+            DB::table('city_islands')->insert([
+                'city_id' => $this->city->id,
+                'island_id' => $island->id,
+            ]);
+        }
     }
 
     /**

--- a/tests/Feature/IslandControllerTest.php
+++ b/tests/Feature/IslandControllerTest.php
@@ -46,6 +46,10 @@ class IslandControllerTest extends TestCase
         $response->assertStatus(200);
         $response->assertViewIs('island.index');
         $response->assertViewHas('islands');
+
+        // ページネーションの検証
+        $viewData = $response->original->getData();
+        $this->assertCount(30, $viewData['islands']);
     }
 
     /**

--- a/tests/Unit/Models/CityTest.php.php
+++ b/tests/Unit/Models/CityTest.php.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Prefecture;
+use App\Models\City;
+
+class CityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $prefecture;
+    protected $city;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->prefecture = Prefecture::factory()->create();
+        $this->city = City::factory()->for($this->prefecture)->create();
+    }
+
+    /**
+     * 市区町村が属する都道府県を取得できるかテスト
+     * @return void
+     */
+    public function test_prefecture(): void
+    {
+        $pref = $this->city->prefecture;
+
+        // 取得した都道府県のIDが、テストデータの都道府県のIDと一致するか
+        $this->assertEquals($this->prefecture->id, $pref->id);
+    }
+}

--- a/tests/Unit/Models/IslandTest.php
+++ b/tests/Unit/Models/IslandTest.php
@@ -49,7 +49,7 @@ class IslandTest extends TestCase
      * Indexページ用の全件取得メソッドをテスト
      * @return void
      */
-    public function test_get_all_for_index()
+    public function test_get_all_for_index(): void
     {
         $this->assertEquals(100, count(Island::getAllForIndex()));
 

--- a/tests/Unit/Models/IslandTest.php
+++ b/tests/Unit/Models/IslandTest.php
@@ -46,12 +46,14 @@ class IslandTest extends TestCase
     }
 
     /**
-     * 全件取得できるかテスト
+     * Indexページ用の全件取得メソッドをテスト
      * @return void
      */
-    public function test_get_all_records()
+    public function test_get_all_for_index()
     {
-        $this->assertEquals(100, Island::getAll()->count());
+        $this->assertEquals(100, count(Island::getAllForIndex()));
+
+        // TODO: 取得結果の検証
     }
 
     /**

--- a/tests/Unit/Models/IslandTest.php
+++ b/tests/Unit/Models/IslandTest.php
@@ -53,7 +53,13 @@ class IslandTest extends TestCase
     {
         $this->assertEquals(100, count(Island::getAllForIndex()));
 
-        // TODO: 取得結果の検証
+        // 取得結果の検証
+        foreach(Island::getAllForIndex() as $index => $island) {
+            $this->assertEquals($this->islands[$index]->id, $island->id);
+            $this->assertEquals($this->islands[$index]->name, $island->name);
+            $this->assertEquals($this->prefecture->name, $island->prefecture_name);
+            $this->assertEquals($this->city->name, $island->city_name);
+        }
     }
 
     /**

--- a/tests/Unit/Models/IslandTest.php
+++ b/tests/Unit/Models/IslandTest.php
@@ -35,4 +35,6 @@ class IslandTest extends TestCase
     {
         $this->assertEquals(100, Island::getAll()->count());
     }
+
+    // TOOO: citiesのテストを書く
 }

--- a/tests/Unit/Models/IslandTest.php
+++ b/tests/Unit/Models/IslandTest.php
@@ -51,15 +51,9 @@ class IslandTest extends TestCase
      */
     public function test_get_all_for_index(): void
     {
-        $this->assertEquals(100, count(Island::getAllForIndex()));
+        $this->assertEquals(100, Island::getAllForIndex()->count());
 
-        // 取得結果の検証
-        foreach(Island::getAllForIndex() as $index => $island) {
-            $this->assertEquals($this->islands[$index]->id, $island->id);
-            $this->assertEquals($this->islands[$index]->name, $island->name);
-            $this->assertEquals($this->prefecture->name, $island->prefecture_name);
-            $this->assertEquals($this->city->name, $island->city_name);
-        }
+        // TODO: ここで、島の名前、都道府県名、市区町村名が取得できているかテストしたい
     }
 
     /**

--- a/tests/Unit/Models/PrefectureTest.php
+++ b/tests/Unit/Models/PrefectureTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Prefecture;
+use Illuminate\Support\Facades\DB;
+
+class PrefectureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $prefecture;
+    protected $other_prefecture;
+    protected $cities;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->prefecture = Prefecture::factory()->create();
+        $this->other_prefecture = Prefecture::factory()->create();
+
+        // テストデータを作成
+        $this->cities = [
+            [
+                'id' => 1,
+                'prefecture_id' => $this->prefecture->id,
+                'name' => 'テスト1',
+                'en_name' => 'test1',
+                'code' => 'TS1',
+            ],
+            [
+                'id' => 2,
+                'prefecture_id' => $this->prefecture->id,
+                'name' => 'テスト2',
+                'en_name' => 'test2',
+                'code' => 'TS2',
+            ],
+            [
+                'id' => 3,
+                'prefecture_id' => $this->other_prefecture->id,
+                'name' => 'テスト3',
+                'en_name' => 'test3',
+                'code' => 'TS3',
+            ],
+        ];
+
+        // 連想配列をベースにデータを作成
+        foreach ($this->cities as $city) {
+            DB::table('cities')->insert([
+                'id' => $city['id'],
+                'prefecture_id' => $city['prefecture_id'],
+                'name' => $city['name'],
+                'en_name' => $city['en_name'],
+                'code' => $city['code'],
+            ]);
+        }
+    }
+
+    /**
+     * 都道府県に属する市区町村を取得できるかテスト
+     * @return void
+     */
+    public function test_cities(): void
+    {
+        $cities = $this->prefecture->cities();
+
+        // 2件取得できているか
+        $this->assertEquals(2, $cities->count());
+        // 取得したデータのnameがテスト1とテスト2であるか
+        $this->assertTrue($cities->pluck('name')->contains('テスト1'));
+        $this->assertTrue($cities->pluck('name')->contains('テスト2'));
+        // 取得したデータのnameにテスト3が含まれていないか
+        $this->assertFalse($cities->pluck('name')->contains('テスト3'));
+    }
+}

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -43,6 +43,7 @@ class IslandIndex extends TestCase
         $response = $this->actingAs($this->user)->get('/');
 
         $response->assertStatus(200);
+        $response->assertViewHas('islands');
         $response
             ->assertSee('島一覧')
             ->assertSee('<th>島名</th>', false)

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -30,6 +30,11 @@ class IslandIndex extends TestCase
         $response = $this->actingAs($this->user)->get('/');
 
         $response->assertStatus(200);
-        $response->assertSee('島一覧');
+        $response
+            ->assertSee('島一覧')
+            ->assertSee('<th>島名</th>', false)
+            ->assertSee('<th>都道府県名</th>', false)
+            ->assertSee('<th>市区町村名</th>', false)
+            ->assertSee("<td>{$this->islands[0]->name}</td>", false);
     }
 }

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit\Views;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Island;
+
+class IslandIndex extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+    protected $islands;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->islands = Island::factory(100)->create();
+    }
+
+    /**
+     * 島の一覧画面で必要な要素が描画されているかテスト
+     * @return void
+     */
+    public function test_index_page(): void
+    {
+        $response = $this->actingAs($this->user)->get('/');
+
+        $response->assertStatus(200);
+        $response->assertSee('島一覧');
+    }
+}

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -48,6 +48,7 @@ class IslandIndex extends TestCase
             ->assertSee('<th>島名</th>', false)
             ->assertSee('<th>都道府県名</th>', false)
             ->assertSee('<th>市区町村名</th>', false)
+            ->assertSee('pagination', false)
             // NOTE: 各島の詳細ページへのリンクがあるかどうかテストしたい
             ->assertSeeInOrder(["<td>", $this->islands[0]->name, "</td>"], false);
     }

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -6,19 +6,32 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\User;
 use App\Models\Island;
-
+use App\Models\Prefecture;
+use App\Models\City;
+use Illuminate\Support\Facades\DB;
 class IslandIndex extends TestCase
 {
     use RefreshDatabase;
 
     protected $user;
+    protected $prefecture;
+    protected $city;
     protected $islands;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->user = User::factory()->create();
+        $this->prefecture = Prefecture::factory()->create();
+        $this->city = City::factory()->for($this->prefecture)->create();
         $this->islands = Island::factory(100)->create();
+
+        foreach ($this->islands as $island) {
+            DB::table('city_islands')->insert([
+                'city_id' => $this->city->id,
+                'island_id' => $island->id,
+            ]);
+        }
     }
 
     /**

--- a/tests/Unit/Views/IslandIndex.php
+++ b/tests/Unit/Views/IslandIndex.php
@@ -35,6 +35,7 @@ class IslandIndex extends TestCase
             ->assertSee('<th>島名</th>', false)
             ->assertSee('<th>都道府県名</th>', false)
             ->assertSee('<th>市区町村名</th>', false)
-            ->assertSee("<td>{$this->islands[0]->name}</td>", false);
+            // NOTE: 各島の詳細ページへのリンクがあるかどうかテストしたい
+            ->assertSeeInOrder(["<td>", $this->islands[0]->name, "</td>"], false);
     }
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `IslandController.php`の`index`メソッドが変更されました。`Island::getAll()`の代わりに`Island::getAllForIndex()->paginate(30)`が使用されるようになりました。
- New Feature: `City.php`モデルに`prefecture`メソッドが追加されました。
- New Feature: `CityIsland.php`モデルクラスが新しく追加されました。
- New Feature: `Island.php`モデルにいくつかの新しいメソッドが追加されました。
- New Feature: `Prefecture.php`モデルに`cities`メソッドが追加されました。
- Refactor: `AppServiceProvider.php`クラスの`boot`メソッドに2つの変更が行われました。
- Test: `IslandControllerTest.php`クラスにいくつかの変更が加えられました。
- Test: `CityTest.php`クラスに`test_prefecture`メソッドが追加されました。
- Test: `IslandTest.php`クラスにいくつかの新しいテストメソッドとデータが追加されました。
- Test: `PrefectureTest.php`クラスに`test_cities`メソッドが追加されました。
- Test: `IslandIndex.php`テストクラスが追加されました。

以上の変更セットが含まれています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->