### PR TITLE
#38 Actions修正、シーダーのコメントアウト

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,7 @@ on:
     types: [opened]
     branches-ignore:
       - main
+      - develop
   pull_request_review_comment:
     types: [created]
   issue_comment:

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,12 +16,12 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             // テスト用ユーザー作成
-            UsersTableSeeder::class,
+            // UsersTableSeeder::class,
             // 初期データ作成
-            PrefecturesTableSeeder::class,
-            CitiesTableSeeder::class,
-            IslandsTableSeeder::class,
-            CityIslandsTableSeeder::class,
+            // PrefecturesTableSeeder::class,
+            // CitiesTableSeeder::class,
+            // IslandsTableSeeder::class,
+            // CityIslandsTableSeeder::class,
         ]);
     }
 }

--- a/scripts/00-laravel-deploy.sh
+++ b/scripts/00-laravel-deploy.sh
@@ -9,9 +9,8 @@ php artisan config:cache
 echo 'Caching routes...'
 php artisan route:cache
 
-# デプロイ時に既存のデータをリセット&マイグレーション TODO: #12が解決したら削除
 echo 'Running migrations...'
-php artisan migrate:fresh --force
+php artisan migrate --force
 
-echo 'Running seeders...'
-php artisan db:seed --force
+# echo 'Running seeders...'
+# php artisan db:seed --force


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Chore: `.github/workflows/review.yml`の変更は、GitHub Actionsのトリガー設定に関連しています。`main`ブランチと`develop`ブランチが除外されるようになりました。この変更はロジックや機能に直接的な影響を与えるわけではありませんが、`NEEDS_REVIEW`として扱われるべきです。

- Refactor: `database/seeders/DatabaseSeeder.php`と`scripts/00-laravel-deploy.sh`の変更は、データベースのシーディングに関連しています。`DatabaseSeeder.php`ではいくつかのクラスがコメントアウトされ、`00-laravel-deploy.sh`ではマイグレーションとシーディングの手順に変更が加えられました。これらの変更はロジックや機能に直接的な変更をもたらすわけではありませんが、データベースの初期化やデプロイ手順に影響を与える可能性があるため、`NEEDS_REVIEW`として扱われるべきです。

以上の変更セットを含むプルリクエストのリリースノートを作成しました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->