### PR TITLE
#59 island_questionsテーブルのマイグレーションファイルを追加

### DIFF
--- a/database/migrations/2023_11_07_161015_create_island_questions_table.php
+++ b/database/migrations/2023_11_07_161015_create_island_questions_table.php
@@ -30,6 +30,9 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('island_questions', function (Blueprint $table) {
+            $table->dropForeign(['island_id']);
+        });
         Schema::dropIfExists('island_questions');
     }
 };

--- a/database/migrations/2023_11_07_161015_create_island_questions_table.php
+++ b/database/migrations/2023_11_07_161015_create_island_questions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('island_questions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('island_id')->constrained('islands');
+            $table->string('firestore_id', 100)->comment('Firestore ID')->index();
+            $table->string('question', 100)->comment('質問文');
+            $table->integer('answer_count')->comment('回答数');
+            $table->boolean('is_default')->comment('デフォルト質問かどうか');
+            $table->timestamp('posted_at')->comment('投稿日時');
+            $table->foreignId('posted_user_id')->comment('投稿者のFirestore ID');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('island_questions');
+    }
+};

--- a/tests/Unit/Migrations/CitiesTableTest.php
+++ b/tests/Unit/Migrations/CitiesTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Migrations;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
@@ -19,8 +19,8 @@ class CitiesTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するかどうか
-    */
+     * 必要なカラムが存在するかどうか
+     */
     public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('cities', [
@@ -35,8 +35,8 @@ class CitiesTableTest extends TestCase
     }
 
     /**
-    * prefecture_idはprefecturesテーブルのidを参照しているか
-    */
+     * prefecture_idはprefecturesテーブルのidを参照しているか
+     */
     public function test_prefecture_id_foreign(): void
     {
         $this->assertTrue(Schema::enableForeignKeyConstraints('prefecture_id'));

--- a/tests/Unit/Migrations/CityIslandsTableTest.php
+++ b/tests/Unit/Migrations/CityIslandsTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Migrations;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
@@ -19,8 +19,8 @@ class CityIslandsTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するかどうか
-    */
+     * 必要なカラムが存在するかどうか
+     */
     public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('city_islands', [
@@ -33,16 +33,16 @@ class CityIslandsTableTest extends TestCase
     }
 
     /**
-    * city_idはcitiesテーブルのidを参照しているか
-    */
+     * city_idはcitiesテーブルのidを参照しているか
+     */
     public function test_city_id_foreign(): void
     {
         $this->assertTrue(Schema::enableForeignKeyConstraints('city_id'));
     }
 
     /**
-    * island_idはislandsテーブルのidを参照しているか
-    */
+     * island_idはislandsテーブルのidを参照しているか
+     */
     public function test_island_id_foreign(): void
     {
         $this->assertTrue(Schema::enableForeignKeyConstraints('island_id'));

--- a/tests/Unit/Migrations/IslandQuestionsTableTest.php
+++ b/tests/Unit/Migrations/IslandQuestionsTableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Migrations;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class IslandQuestionsTableTest extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * island_questionsテーブルが存在するかどうか
+     */
+    public function test_exists_island_questions_table(): void
+    {
+        $this->assertTrue(Schema::hasTable('island_questions'));
+    }
+
+    /**
+     * 必要なカラムが存在するかどうか
+     */
+    public function test_has_necessary_columns()
+    {
+        $this->assertTrue(Schema::hasColumns('island_questions', [
+            'id',
+            'island_id',
+            'firestore_id',
+            'question',
+            'answer_count',
+            'is_default',
+            'posted_at',
+            'posted_user_id',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+
+    /**
+     * island_idはislandsテーブルのidを参照しているか
+     */
+    public function test_island_id_foreign(): void
+    {
+        $this->assertTrue(Schema::enableForeignKeyConstraints('island_id'));
+    }
+}

--- a/tests/Unit/Migrations/IslandsTableTest.php
+++ b/tests/Unit/Migrations/IslandsTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Migrations;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
@@ -19,8 +19,8 @@ class IslandsTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するかどうか
-    */
+     * 必要なカラムが存在するかどうか
+     */
     public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('islands', [

--- a/tests/Unit/Migrations/PrefecturesTableTest.php
+++ b/tests/Unit/Migrations/PrefecturesTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Unit\Migrations;
 
 use Tests\TestCase;
 use Illuminate\Support\Facades\Schema;
@@ -19,8 +19,8 @@ class PrefecturesTableTest extends TestCase
     }
 
     /**
-    * 必要なカラムが存在するかどうか
-    */
+     * 必要なカラムが存在するかどうか
+     */
     public function test_has_necessary_columns(): void
     {
         $this->assertTrue(Schema::hasColumns('prefectures', [


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `island_questions`テーブルのマイグレーションファイルが追加されました。新しいテーブルには、質問と回答に関する情報が含まれます。
- Refactor: `Tests\Unit`の名前空間が`Tests\Unit\Migrations`に変更され、コメントのインデントが修正されました。
- Test: `city_islands`テーブルのマイグレーションファイルに対するテストが追加されました。必要なカラムの存在や外部キー制約の正しさを確認します。
- Test: `island_questions`テーブルのマイグレーションファイルに対するテストが追加されました。テーブルの存在、必要なカラムの存在、外部キー制約がテストされます。
- Refactor: `IslandsTableTest.php`の名前空間が`Tests\Unit\Migrations`に変更され、コメントが修正されました。
- Refactor: `PrefecturesTableTest.php`の名前空間が`Tests\Unit\Migrations`に変更されました。

Note: このリリースノートは、プルリクエストの概要と変更セットの要約を反映しています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->