### PR TITLE
#60 question_answersテーブルの追加

### DIFF
--- a/database/migrations/2023_11_07_164531_create_question_answers_table.php
+++ b/database/migrations/2023_11_07_164531_create_question_answers_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_answers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('question_id')->constrained('island_questions');
+            $table->string('firestore_id', 100)->comment('Firestore ID')->index();
+            $table->string('answer', 800)->comment('回答文');
+            $table->integer('liked_count')->comment('高評価数');
+            $table->integer('disliked_count')->comment('低評価数');
+            $table->string('posted_user_id', 100)->comment('投稿者のFirestore ID');
+            $table->timestamp('posted_at')->comment('投稿日時');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('question_answers', function (Blueprint $table) {
+            $table->dropForeign(['question_id']);
+        });
+        Schema::dropIfExists('question_answers');
+    }
+};

--- a/tests/Unit/Migrations/QuestionAnswersTable.php
+++ b/tests/Unit/Migrations/QuestionAnswersTable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\Migrations;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+
+class QuestionAnswersTable extends TestCase
+{
+    use DatabaseMigrations;
+
+    /**
+     * question_answersテーブルが存在するかどうか
+     */
+    public function test_exists_question_answers_table(): void
+    {
+        $this->assertTrue(Schema::hasTable('question_answers'));
+    }
+
+    /**
+     * 必要なカラムが存在するかどうか
+     */
+    public function test_has_necessary_columns()
+    {
+        $this->assertTrue(Schema::hasColumns(
+            'question_answers',
+            [
+                'id',
+                'question_id',
+                'firestore_id',
+                'answer',
+                'liked_count',
+                'disliked_count',
+                'posted_at',
+                'posted_user_id',
+                'created_at',
+                'updated_at',
+            ]
+        ));
+    }
+
+    /**
+     * question_idはisland_questionsテーブルのidを参照しているか
+     */
+    public function test_question_id_foreign(): void
+    {
+        $this->assertTrue(Schema::enableForeignKeyConstraints('question_id'));
+    }
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: 新しいマイグレーションファイル `2023_11_07_164531_create_question_answers_table.php` が追加されました。これにより、`question_answers` テーブルが作成され、質問の回答に関する情報を格納できるようになります。
- Test: 新しいテストクラス `QuestionAnswersTable` が追加されました。このテストクラスは、`question_answers` テーブルの存在、必要なカラムの存在、および `question_id` カラムが `island_questions` テーブルの `id` を参照しているかを確認するテストメソッドを含んでいます。

以上の変更が含まれています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->