### PR TITLE
#62 質問・回答を島の詳細ページで表示

### DIFF
--- a/database/seeders/AnswersTableSampleSeeder.php
+++ b/database/seeders/AnswersTableSampleSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
 
 class AnswersTableSampleSeeder extends Seeder
 {
@@ -20,9 +21,9 @@ class AnswersTableSampleSeeder extends Seeder
                 'liked_count' => 1,
                 'disliked_count' => 0,
                 'posted_user_id' => 'hogehoge',
-                'posted_at' => now(),
-                'created_at' => now(),
-                'updated_at' => now(),
+                'posted_at' => Carbon::now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
             [
                 'question_id' => 2,
@@ -31,9 +32,9 @@ class AnswersTableSampleSeeder extends Seeder
                 'liked_count' => 1,
                 'disliked_count' => 0,
                 'posted_user_id' => 'fugafuga',
-                'posted_at' => now(),
-                'created_at' => now(),
-                'updated_at' => now(),
+                'posted_at' => Carbon::now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
             [
                 'question_id' => 2,
@@ -42,9 +43,9 @@ class AnswersTableSampleSeeder extends Seeder
                 'liked_count' => 0,
                 'disliked_count' => 0,
                 'posted_user_id' => 'piyopiyo',
-                'posted_at' => now(),
-                'created_at' => now(),
-                'updated_at' => now(),
+                'posted_at' => Carbon::now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
         ]);
     }

--- a/database/seeders/AnswersTableSampleSeeder.php
+++ b/database/seeders/AnswersTableSampleSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class AnswersTableSampleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('answers')->insert([
+            [
+                'question_id' => 1,
+                'firestore_id' => 'hoge',
+                'answer' => 'サンプル回答1',
+                'liked_count' => 1,
+                'disliked_count' => 0,
+                'posted_user_id' => 'hogehoge',
+                'posted_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'question_id' => 2,
+                'firestore_id' => 'fugafuga',
+                'answer' => 'サンプル回答2',
+                'liked_count' => 1,
+                'disliked_count' => 0,
+                'posted_user_id' => 'fugafuga',
+                'posted_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'question_id' => 2,
+                'firestore_id' => 'piyopiyo',
+                'answer' => 'サンプル回答3',
+                'liked_count' => 0,
+                'disliked_count' => 0,
+                'posted_user_id' => 'piyopiyo',
+                'posted_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,9 +2,6 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
-
-use App\Models\Prefecture;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -23,8 +20,8 @@ class DatabaseSeeder extends Seeder
             IslandsTableSeeder::class,
             CityIslandsTableSeeder::class,
             // サンプルデータ作成 ※本番環境では実行しない
-            QuestionsTableSampleSeeder::class,
-            AnswersTableSampleSeeder::class,
+            //QuestionsTableSampleSeeder::class,
+            //AnswersTableSampleSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,9 @@ class DatabaseSeeder extends Seeder
             CitiesTableSeeder::class,
             IslandsTableSeeder::class,
             CityIslandsTableSeeder::class,
+            // サンプルデータ作成 ※本番環境では実行しない
+            QuestionsTableSampleSeeder::class,
+            AnswersTableSampleSeeder::class,
         ]);
     }
 }

--- a/database/seeders/QuestionsTableSampleSeeder.php
+++ b/database/seeders/QuestionsTableSampleSeeder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class QuestionsTableSampleSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('questions')->insert([
+            [
+                'id' => 1,
+                'island_id' => 1,
+                'firestore_id' => 'hoge',
+                'question' => 'サンプル質問1',
+                'answer_count' => 1,
+                'is_default' => true,
+                'posted_at' => now(),
+                'posted_user_id' => 'hogehoge',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => 2,
+                'island_id' => 1,
+                'firestore_id' => 'fuga',
+                'question' => 'サンプル質問2',
+                'answer_count' => 2,
+                'is_default' => true,
+                'posted_at' => now(),
+                'posted_user_id' => 'fugafuga',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => 3,
+                'island_id' => 2,
+                'firestore_id' => 'piyo',
+                'question' => 'サンプル質問3',
+                'answer_count' => 0,
+                'is_default' => false,
+                'posted_at' => now(),
+                'posted_user_id' => 'piyopiyo',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/database/seeders/QuestionsTableSampleSeeder.php
+++ b/database/seeders/QuestionsTableSampleSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
 
 class QuestionsTableSampleSeeder extends Seeder
 {
@@ -20,10 +21,10 @@ class QuestionsTableSampleSeeder extends Seeder
                 'question' => 'サンプル質問1',
                 'answer_count' => 1,
                 'is_default' => true,
-                'posted_at' => now(),
+                'posted_at' => Carbon::now(),
                 'posted_user_id' => 'hogehoge',
-                'created_at' => now(),
-                'updated_at' => now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
             [
                 'id' => 2,
@@ -32,10 +33,10 @@ class QuestionsTableSampleSeeder extends Seeder
                 'question' => 'サンプル質問2',
                 'answer_count' => 2,
                 'is_default' => true,
-                'posted_at' => now(),
+                'posted_at' => Carbon::now(),
                 'posted_user_id' => 'fugafuga',
-                'created_at' => now(),
-                'updated_at' => now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
             [
                 'id' => 3,
@@ -44,10 +45,11 @@ class QuestionsTableSampleSeeder extends Seeder
                 'question' => 'サンプル質問3',
                 'answer_count' => 0,
                 'is_default' => false,
-                'posted_at' => now(),
+                'posted_at' =>
+                Carbon::now(),
                 'posted_user_id' => 'piyopiyo',
-                'created_at' => now(),
-                'updated_at' => now(),
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
             ],
         ]);
     }

--- a/resources/views/island/show.blade.php
+++ b/resources/views/island/show.blade.php
@@ -38,4 +38,40 @@
             </tbody>
         </table>
     </div>
+
+    <h5 class="mb-2">質問</h5>
+    <? @if ($island->questions->count() > 0)
+                                                                    : ?>
+    <div class="card">
+        <? @foreach ($island->questions as $question)
+    : ?>
+        <div class="card-header">
+            <h3 class="card-title">{{ $question->question }}</h3>
+            <div class="card-tools">
+                <a>編集リンク</a>
+            </div>
+        </div>
+        <div class="card-body">
+            <? @if ($question->answers->count() > 0)
+    : ?>
+            <? @foreach ($question->answers as $answer)
+    : ?>
+            {{ $answer->answer }}
+            <br>
+            <a><i class="fas fa-edit"></i>編集リンク</a>
+            <hr>
+
+            <?
+    @endforeach; ?>
+            <? @else: ?>
+            <p>この質問に対する回答はありません。</p>
+            <?
+    @endif; ?>
+        </div>
+        <?
+    @endforeach; ?>
+    </div>
+    <? @else: ?>
+    <p>この島に関する質問はありません。</p>
+    <? @endif; ?>
 @stop

--- a/tests/Unit/Views/IslandIndexTest.php
+++ b/tests/Unit/Views/IslandIndexTest.php
@@ -9,7 +9,8 @@ use App\Models\Island;
 use App\Models\Prefecture;
 use App\Models\City;
 use Illuminate\Support\Facades\DB;
-class IslandIndex extends TestCase
+
+class IslandIndexTest extends TestCase
 {
     use RefreshDatabase;
 

--- a/tests/Unit/Views/IslandShowTest.php
+++ b/tests/Unit/Views/IslandShowTest.php
@@ -2,15 +2,17 @@
 
 namespace Tests\Feature\Views;
 
+use App\Models\Answer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\User;
 use App\Models\Island;
 use App\Models\Prefecture;
 use App\Models\City;
+use App\Models\Question;
 use Illuminate\Support\Facades\DB;
 
-class IslandShow extends TestCase
+class IslandShowTest extends TestCase
 {
     use RefreshDatabase;
 
@@ -39,7 +41,7 @@ class IslandShow extends TestCase
      */
     public function test_show_page(): void
     {
-        $response = $this->actingAs($this->user)->get("/island/{$this->island->id}");
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
 
         $response->assertStatus(200);
         $response->assertViewHas('island')
@@ -60,7 +62,8 @@ class IslandShow extends TestCase
             ->assertSee("<th>緯度</th>", false)
             ->assertSee($this->island->lat, false)
             ->assertSee("<th>経度</th>", false)
-            ->assertSee($this->island->lng, false);
+            ->assertSee($this->island->lng, false)
+            ->assertSee("質問", false);
     }
 
     /**
@@ -74,8 +77,59 @@ class IslandShow extends TestCase
             'island_id' => $this->island->id,
         ]);
 
-        $response = $this->actingAs($this->user)->get("/island/{$this->island->id}");
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
         $response->assertSee("<th>市区町村</th>", false)
             ->assertSee("{$this->city->name} 他", false);
+    }
+
+    /**
+     * 質問がある場合は、質問が表示されるかテスト
+     */
+    public function test_show_page_with_questions()
+    {
+        $questions = Question::factory(3)->for($this->island)->create();
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
+        $response->assertSee("質問", false)
+            ->assertSee($questions[0]->question, false)
+            ->assertSee($questions[1]->question, false)
+            ->assertSee($questions[2]->question, false);
+    }
+
+    /**
+     * 質問がない場合は、その旨の文言が表示されるかテスト
+     */
+    public function test_show_page_without_questions()
+    {
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
+        $response->assertSee("質問", false)
+            ->assertSee("この島に関する質問はありません。", false);
+    }
+
+    /**
+     * 質問に回答がある場合は、質問の回答が表示されるかテスト
+     */
+    public function test_show_page_with_answers()
+    {
+        $question = Question::factory()->for($this->island)->create();
+        $answers = Answer::factory(3)->for($question)->create();
+
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
+        $response->assertSee("質問", false)
+            ->assertSee($answers[0]->answer, false)
+            ->assertSee($answers[1]->answer, false)
+            ->assertSee($answers[2]->answer, false);
+    }
+
+    /**
+     * 質問に回答がない場合は、その旨の文言が表示されるかテスト
+     */
+    public function test_show_page_without_answers()
+    {
+        $question = Question::factory()->for($this->island)->create();
+
+        $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
+        $response->assertSee("質問", false)
+            ->assertSee($question->question, false)
+            ->assertSee("この質問に対する回答はありません。", false);
     }
 }

--- a/tests/Unit/Views/IslandShowTest.php
+++ b/tests/Unit/Views/IslandShowTest.php
@@ -115,6 +115,7 @@ class IslandShowTest extends TestCase
 
         $response = $this->actingAs($this->user)->get("/islands/{$this->island->id}");
         $response->assertSee("質問", false)
+            ->assertSee($question->question, false)
             ->assertSee($answers[0]->answer, false)
             ->assertSee($answers[1]->answer, false)
             ->assertSee($answers[2]->answer, false);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `AnswersTableSampleSeeder`というシーダークラスが追加され、`answers`テーブルに3つのサンプル回答が挿入されるようになりました。各回答には質問ID、Firestore ID、回答内容、いいね数、いいね解除数、投稿ユーザーID、投稿日時、作成日時、更新日時が含まれます。
- Refactor: `DatabaseSeeder`に新しいシーダークラスが追加され、質問と回答のテーブルにサンプルデータを追加するための準備作業が行われるようになりました。この変更はロジックや機能に直接的な影響を与えませんが、データベースにサンプルデータを追加するための重要な変更です。
- New Feature: `QuestionsTableSampleSeeder`というシーダークラスが追加され、`questions`テーブルに新しいレコードが追加されるようになりました。追加されるレコードには、質問の内容や回答数などの情報が含まれています。
- New Feature: 島の詳細ページに質問と回答を表示するセクションが追加されました。質問とそれに対応する回答をカード形式で表示します。質問や回答が存在しない場合は適切なメッセージが表示されます。
- Chore: `IslandIndex`クラスのテストケース名が`IslandIndexTest`に変更されました。この変更はテストクラスの命名規則を修正するためのものであり、外部インターフェースやコードの振る舞いには影響しません。
- Test: `IslandShow`テストクラスに新しいテストメソッドが追加され、島の詳細ページに関連する質問と回答が正しく表示されるかどうかを確認します。

以上がプルリクエストの変更内容です。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->